### PR TITLE
Various changes to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,22 @@
-# ubuntu 16.04 xenial image
-FROM ubuntu
+# use base python
+FROM python:2.7-alpine
 
-# apt update it
-RUN apt-get update
-# get essentials
-RUN apt-get install -y tar git curl wget dialog net-tools build-essential python python-dev python-distribute python-pip
+# install deps
+RUN apk add --no-cache bash curl git mailcap tar wget
 
-# add project directory
-ADD . /telemetry-schema-service/
+# create app directory
+RUN mkdir -p /app/
+WORKDIR /app/
 
-# pip install requirements.txt
-RUN pip install -r /telemetry-schema-service/requirements.txt
+# install requirements
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir --requirement requirements.txt
 
-# exposing 8080 for flask app
+# expose 8080 for flask app
 EXPOSE 8080
 
-# workdir
-WORKDIR /telemetry-schema-service/app
+# copy application
+COPY . /app/
 
-# run gunicorn
-CMD gunicorn -w 4 -b 0.0.0.0:8080 mozschemas_service:app
+# run start script
+CMD ["bin/start"]

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eo pipefail
+
+: ${WORKERS:=4}
+: ${PORT:=8080}
+
+exec gunicorn -w $WORKERS -b 0.0.0.0:$PORT app.mozschemas_service:app


### PR DESCRIPTION
- Use the "python:2.7-alpine" base image
- Put application in /app as per "Dockerflow"
- Add script that uses $PORT and $WORKERS when starting gunicorn
- Re-order steps to take advantage of caching
