### PR TITLE
Fixing home page 404

### DIFF
--- a/app/mozschemas_service.py
+++ b/app/mozschemas_service.py
@@ -50,6 +50,9 @@ def allowed_file(filename):
     return '.' in filename and \
         filename.rsplit('.', 1)[1] in ALLOWED_EXTENSIONS
 
+@app.route('/', strict_slashes=False)
+def api_home():
+    return redirect('/schema/telemetry')
 
 @app.route('/__version__', strict_slashes=False)
 def api_version():


### PR DESCRIPTION
To review before merge - @mreid-moz , @robotblake , @maurodoglio 
 Changes:
1. endpoint `schemas.telemetry.mozilla.org/` redirects to `schemas.telemetry.mozilla.org/schema/telemetry`
